### PR TITLE
Use dtolnay/rust-toolchain for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,18 +29,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        profile: minimal
-        target: ${{ matrix.target }}
-        override: true
+        targets: ${{ matrix.target }}
     - name: Run cargo build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --locked --target ${{ matrix.target }}
-        use-cross: ${{ matrix.os == 'ubuntu-latest' }}
+      run: cargo build --release --locked --target ${{ matrix.target }}
+      # use-cross: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Prepare Windows package
       if: matrix.os == 'windows-latest'
       run: |
@@ -65,11 +59,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - id: version
       name: Get version number
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,10 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: ${{ matrix.target }}
-    - name: Run cargo build
-      run: cargo build --release --locked --target ${{ matrix.target }}
-      # use-cross: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Install Cross
+      run: cargo install cross
+    - name: Build Spreet
+      run: cross build --release --locked --target ${{ matrix.target }}
     - name: Prepare Windows package
       if: matrix.os == 'windows-latest'
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
       with:
-        targets: ${{ matrix.target }}
+        target: ${{ matrix.target }}
     - name: Install Cross
       run: cargo install cross
     - name: Build Spreet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Build new version
-on: [push]
+on:
+  push:
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"
 jobs:
   build:
     name: Build release binaries
@@ -67,3 +70,12 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         path: ./bin
+    - name: Create draft release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: v${{ steps.version.outputs.version }}
+        draft: true
+        generate_release_notes: true
+        files: |
+          ./bin/**/*.zip
+          ./bin/**/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Build new version
-on:
-  push:
-    tags:
-    - "v[0-9]+.[0-9]+.[0-9]+"
+on: [push]
 jobs:
   build:
     name: Build release binaries
@@ -69,12 +66,3 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         path: ./bin
-    - name: Create draft release
-      uses: softprops/action-gh-release@v1
-      with:
-        name: v${{ steps.version.outputs.version }}
-        draft: true
-        generate_release_notes: true
-        files: |
-          ./bin/**/*.zip
-          ./bin/**/*.tar.gz


### PR DESCRIPTION
The final part of #35, replacing the unmaintained [actions-rs/toolchain](https://github.com/actions-rs/toolchain) with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) when drafting a new release. 