### PR TITLE
Publish Spreet to crates.io when a new version is released

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -1,4 +1,4 @@
-name: Build new version
+name: Create new draft release
 on:
   push:
     tags:

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -1,6 +1,7 @@
 name: Publish new release to crates.io
 on:
-  push:
+  release:
+    types: [released]
 jobs:
   publish:
     name: cargo publish
@@ -8,6 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --dry-run
+      - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -1,7 +1,6 @@
 name: Publish new release to crates.io
 on:
-  release:
-    types: [released]
+  push:
 jobs:
   publish:
     name: cargo publish

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish
+      - run: cargo publish --dry-run
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -1,0 +1,14 @@
+name: Publish new release to crates.io
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    name: cargo publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The last part of #34. When a new version is released on GitHub it should also be published to crates.io ([see the crate here](https://crates.io/crates/spreet)).