### PR TITLE
Optimize build, spelling, linting

### DIFF
--- a/src/bin/spreet/main.rs
+++ b/src/bin/spreet/main.rs
@@ -17,34 +17,27 @@ fn main() {
     let pixel_ratio = if args.retina { 2 } else { args.ratio };
 
     // Collect the file paths for all SVG images in the input directory.
-    let svg_paths = get_svg_input_paths(&args.input, args.recursive);
-    if svg_paths.is_empty() {
-        eprintln!("Error: no SVGs found in {:?}", &args.input);
-        std::process::exit(exitcode::NOINPUT);
-    }
-
     // Read from all the input SVG files, convert them into bitmaps at the correct pixel ratio, and
     // store them in a map. The keys are the SVG filenames without the `.svg` extension. The
     // bitmapped SVGs will be added to the spritesheet, and the keys will be used as the unique
     // sprite ids in the JSON index file.
-    let sprites = BTreeMap::from_iter(
-        svg_paths
-            .par_iter()
-            .map(|svg_path| {
-                if let Ok(svg) = load_svg(svg_path) {
-                    (
-                        sprite::sprite_name(svg_path, args.input.as_path()),
-                        sprite::generate_pixmap_from_svg(&svg, pixel_ratio).unwrap(),
-                    )
-                } else {
-                    eprintln!("{svg_path:?}: not a valid SVG image");
-                    std::process::exit(exitcode::DATAERR);
-                }
-            })
-            .collect::<Vec<(String, Pixmap)>>(),
-    );
+    let sprites = get_svg_input_paths(&args.input, args.recursive)
+        .par_iter()
+        .map(|svg_path| {
+            if let Ok(svg) = load_svg(svg_path) {
+                (
+                    sprite::sprite_name(svg_path, args.input.as_path()),
+                    sprite::generate_pixmap_from_svg(&svg, pixel_ratio).unwrap(),
+                )
+            } else {
+                eprintln!("{svg_path:?}: not a valid SVG image");
+                std::process::exit(exitcode::DATAERR);
+            }
+        })
+        .collect::<BTreeMap<String, Pixmap>>();
+
     if sprites.is_empty() {
-        eprintln!("Error: no valid SVGs found in {:?}", &args.input);
+        eprintln!("Error: no valid SVGs found in {:?}", args.input);
         std::process::exit(exitcode::NOINPUT);
     }
 
@@ -55,25 +48,24 @@ fn main() {
     if args.unique {
         spritesheet_builder.make_unique();
     };
-    // Save the spritesheet and index file if the sprites could be packed successfully, or exit with
-    // an error code if not.
-    if let Some(spritesheet) = spritesheet_builder.generate() {
-        let spritesheet_path = format!("{}.png", args.output);
-        // Save the bitmapped spritesheet to a local PNG.
-        if let Err(e) = spritesheet.save_spritesheet(&spritesheet_path) {
-            eprintln!("Error: could not save spritesheet to {spritesheet_path} ({e})");
-            std::process::exit(exitcode::IOERR);
-        };
-        // Save the index file to a local JSON file with the same name as the spritesheet.
-        if let Err(e) = spritesheet.save_index(&args.output, args.minify_index_file) {
-            eprintln!(
-                "Error: could not save sprite index to {} ({})",
-                args.output, e
-            );
-            std::process::exit(exitcode::IOERR);
-        };
-    } else {
+
+    // Generate sprite sheet
+    let Some(spritesheet) = spritesheet_builder.generate() else {
         eprintln!("Error: could not pack the sprites within an area fifty times their size.");
         std::process::exit(exitcode::DATAERR);
+    };
+
+    // Save the bitmapped spritesheet to a local PNG.
+    let file_prefix = args.output;
+    let spritesheet_path = format!("{file_prefix}.png");
+    if let Err(e) = spritesheet.save_spritesheet(&spritesheet_path) {
+        eprintln!("Error: could not save spritesheet to {spritesheet_path} ({e})");
+        std::process::exit(exitcode::IOERR);
+    };
+
+    // Save the index file to a local JSON file with the same name as the spritesheet.
+    if let Err(e) = spritesheet.save_index(&file_prefix, args.minify_index_file) {
+        eprintln!("Error: could not save sprite index to {file_prefix} ({e})");
+        std::process::exit(exitcode::IOERR);
     };
 }


### PR DESCRIPTION
* Remove duplicate "is_empty" test - if the iteration is empty, it will produce an empty vec very quickly.
* remove unneeded double referencing for the format (eprintln)

See also https://github.com/shssoichiro/oxipng/issues/519