### PR TITLE
Re-export some types used by public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
 pub mod error;
 pub mod fs;
 pub mod sprite;
+
+// Re-export resvg because its types are used in the spreet API.
+// This removes the need for users of spreet to import resvg separately and manage version compatibility.
+pub use resvg;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,6 @@ pub mod error;
 pub mod fs;
 pub mod sprite;
 
-// Re-export resvg because its types are used in the spreet API.
-// This removes the need for users of spreet to import resvg separately and manage version compatibility.
+// Re-export resvg because its types are used in the spreet API. This removes the need for users of
+// spreet to import resvg separately and manage version compatibility.
 pub use resvg;

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -200,8 +200,8 @@ impl Spritesheet {
 
     /// Encode the spritesheet to the in-memory PNG image.
     ///
-    /// The `spritesheet` `Pixmap` is converted to an in-memory PNG,
-    /// optimised using the [`oxipng`] library.
+    /// The `spritesheet` `Pixmap` is converted to an in-memory PNG, optimised using the [`oxipng`]
+    /// library.
     ///
     /// The spritesheet will match an index that can be retrieved with [`Self::get_index`].
     ///


### PR DESCRIPTION
* Make it possible to use this lib's functionality in memory, without saving the file to the disk first.
* It is better to re-export the external types than to require users to import those dependencies and keep matching the versions.