### PR TITLE
Make CLI-only features optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,5 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Run cargo test
         run: cargo test
+      - name: Run cargo test in lib mode
+        run: cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ predicates = "3"
 lto = "thin"
 strip = true
 codegen-units = 1
+
+[[bin]]
+name = "spreet"
+required-features = ["cli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,21 +11,25 @@ license = "MIT"
 keywords = ["sprite", "svg", "cartography", "vector-tiles", "maplibre"]
 categories = ["command-line-utilities", "encoding", "filesystem", "graphics"]
 
+[features]
+default = ["cli"]
+cli = ["clap", "exitcode", "rayon"]
+
 [dependencies]
-assert_fs = "1.0.13"
-clap = { version = "4.3", features = ["derive"] }
+clap = { version = "4.3", features = ["derive"], optional = true }
 crunch = "0.5.3"
-exitcode = "1.1"
+exitcode = { version = "1.1", optional = true }
 multimap = "0.9"
 oxipng = { version = "8.0", features = ["parallel", "zopfli", "filetime"], default-features = false }
 png = "0.17"
-rayon = "1.7"
+rayon = { version = "1.7", optional = true }
 resvg = "0.34"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
 assert_cmd = "2.0"
+assert_fs = "1.0.13"
 predicates = "3"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["command-line-utilities", "encoding", "filesystem", "graphics"]
 
 [features]
 default = ["cli"]
-cli = ["clap", "exitcode", "rayon"]
+cli = ["dep:clap", "dep:exitcode", "dep:rayon"]
 
 [dependencies]
 clap = { version = "4.3", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ _Spreet_ (also _spreit_, _spret_, _sprit_) is the [Scots](https://en.wikipedia.o
 
 - [Installation](#installation)
 - [Tutorial](#tutorial)
-- [Usage](#usage)
+- [Command-line usage](#command-line-usage)
+- [Using Spreet as a Rust library](#using-spreet-as-a-rust-library)
 - [Benchmarks](#benchmarks)
 
 ## Installation
@@ -83,7 +84,7 @@ By default the JSON index file is pretty-printed, but you can minify it with the
 
 When you create a spritesheet for your production environment, use `--unique --minify-index-file` for best results.
 
-## Usage
+## Command-line usage
 
 ```
 $ spreet --help
@@ -104,6 +105,16 @@ Options:
   -h, --help               Print help
   -V, --version            Print version
 ```
+
+## Using Spreet as a Rust library
+
+The main purpose of Spreet is to be command-line tool, but you can also use it as a library in your own Rust code. To add Spreet as a dependency, include this in your `Cargo.toml`:
+
+```toml
+spreet = { version = "0.8.0", default-features = false }
+```
+
+To learn how to build your spritesheets programatically, see the [Spreet crate docs on docs.rs](https://docs.rs/spreet) and have a [look at the spritesheet tests](https://github.com/flother/spreet/blob/master/tests/sprite.rs).
 
 ## Benchmarks
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "cli")]
+
 use std::path::Path;
 use std::process::Command;
 


### PR DESCRIPTION
This greatly speeds up build for the users of the lib when CLI is not needed.  Sorry forgot to include it in the previous round.

* Users of this crate should put this line in their Cargo.toml (needs to be documented somewhere?):  `spreet = { version = "...", default-features = false }`
* `assert_fs` dependency seemed not to be needed by the primary code, only by the tests
* made all other CLI-only dependencies as optional, but enabled by default via the `cli` feature