### PR TITLE
Make `SpritesheetBuilder::generate` consume `self`

### DIFF
--- a/src/sprite/mod.rs
+++ b/src/sprite/mod.rs
@@ -174,7 +174,7 @@ pub struct SpriteDescription {
 
 /// Builder pattern for `Spritesheet`: construct a `Spritesheet` object using calls to a builder
 /// helper.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct SpritesheetBuilder {
     sprites: Option<BTreeMap<String, Sprite>>,
     references: Option<MultiMap<String, String>>,
@@ -227,10 +227,10 @@ impl SpritesheetBuilder {
         self
     }
 
-    pub fn generate(&self) -> Option<Spritesheet> {
+    pub fn generate(self) -> Option<Spritesheet> {
         Spritesheet::new(
-            self.sprites.clone().unwrap_or_default(),
-            self.references.clone().unwrap_or_default(),
+            self.sprites.unwrap_or_default(),
+            self.references.unwrap_or_default(),
             self.pixel_ratio,
         )
     }


### PR DESCRIPTION
There is rarrely any reason for a builder to remain after `.generate` was called, but currently it requires deep clone even though it gets discarded right after.

Instead, I think `SpritesheetBuilder` itself should be cloneable (just in case someone does need this use case), and make generate consume `self`