### PR TITLE
Hide implementation details with module structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Development version
 
+- **Breaking change:** move all public identifiers to the root of the crate, e.g. `spreet::error::SpreetError` ->  `spreet::SpreetError`, with the exception of `resvg`.
 - Update [oxipng](https://crates.io/crates/oxipng) dependency to [v9.0.0](https://github.com/shssoichiro/oxipng/blob/master/CHANGELOG.md#version-900). This improves compression of PNG spritesheets without visual changes, but the PNGs won't be byte-to-byte compatible with spritesheets output by earlier versions of Spreet
 - Update [resvg](https://crates.io/crates/resvg) dependency to [v0.36.0](https://github.com/RazrFalcon/resvg/blob/master/CHANGELOG.md#user-content-0360---2023-10-01)
 - Remove the deprecated function `spreet::sprite::generate_pixmap_from_svg()`

--- a/src/bin/spreet/main.rs
+++ b/src/bin/spreet/main.rs
@@ -1,8 +1,7 @@
 use std::collections::BTreeMap;
 
 use clap::Parser;
-use spreet::fs::{get_svg_input_paths, load_svg};
-use spreet::sprite;
+use spreet::{get_svg_input_paths, load_svg, sprite_name, Sprite, Spritesheet};
 
 mod cli;
 
@@ -26,9 +25,8 @@ fn main() {
         .iter()
         .map(|svg_path| {
             if let Ok(tree) = load_svg(svg_path) {
-                let sprite =
-                    sprite::Sprite::new(tree, pixel_ratio).expect("failed to load a sprite");
-                if let Ok(name) = sprite::sprite_name(svg_path, args.input.as_path()) {
+                let sprite = Sprite::new(tree, pixel_ratio).expect("failed to load a sprite");
+                if let Ok(name) = sprite_name(svg_path, args.input.as_path()) {
                     (name, sprite)
                 } else {
                     eprintln!("Error: cannot make a valid sprite name from {svg_path:?}");
@@ -39,14 +37,14 @@ fn main() {
                 std::process::exit(exitcode::DATAERR);
             }
         })
-        .collect::<BTreeMap<String, sprite::Sprite>>();
+        .collect::<BTreeMap<String, Sprite>>();
 
     if sprites.is_empty() {
         eprintln!("Error: no valid SVGs found in {:?}", args.input);
         std::process::exit(exitcode::NOINPUT);
     }
 
-    let mut spritesheet_builder = sprite::Spritesheet::build();
+    let mut spritesheet_builder = Spritesheet::build();
     spritesheet_builder.sprites(sprites);
     if args.unique {
         spritesheet_builder.make_unique();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,12 @@
-pub mod error;
-pub mod fs;
-pub mod sprite;
-
 // Re-export resvg because its types are used in the spreet API. This removes the need for users of
 // spreet to import resvg separately and manage version compatibility.
 pub use resvg;
+
+mod error;
+pub use error::{SpreetError, SpreetResult};
+
+mod fs;
+pub use fs::*;
+
+mod sprite;
+pub use sprite::*;

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -1,8 +1,7 @@
 use std::path::Path;
 
 use assert_matches::assert_matches;
-use spreet::error::SpreetError;
-use spreet::fs::get_svg_input_paths;
+use spreet::{get_svg_input_paths, SpreetError};
 
 #[test]
 fn get_svg_input_paths_returns_non_recursive_results() {

--- a/tests/sprite.rs
+++ b/tests/sprite.rs
@@ -2,9 +2,7 @@ use std::path::Path;
 
 use assert_matches::assert_matches;
 use resvg::usvg::{Options, Rect, Tree, TreeParsing};
-use spreet::error::SpreetError;
-use spreet::fs::load_svg;
-use spreet::sprite::{sprite_name, Sprite};
+use spreet::{load_svg, sprite_name, SpreetError, Sprite};
 
 #[test]
 fn sprite_name_works_with_root_files() {


### PR DESCRIPTION
For a relatively small crate like this, I think it is unnecesary verbose to use nested repeated identifiers like `spreet::error::SpreetError`.  Instead, I propose to move all the crate-defined IDs to the root like `spreet::SpreetError`. The only exception is the `resvg` because it represents a big crate itself.