### PR TITLE
Add Dockerfile and publish it to GHCR, added release instructions.

### DIFF
--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4 
       - name: Get package version
         id: get_version
-        run: echo "VERSION=$(grep '^version' Cargo.toml | head -n 1 | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
+        run: echo "VERSION=$(grep '^version = "' Cargo.toml | head -n 1 | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 
+      - name: Get package version
+        id: get_version
+        run: echo "VERSION=$(grep '^version' Cargo.toml | head -n 1 | cut -d '"' -f 2)" >> "$GITHUB_OUTPUT"
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -28,7 +31,8 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build . -t ghcr.io/harelm/spreet:latest
+          docker build . -t ghcr.io/harelm/spreet:latest -t ghcr.io/harelm/spreet:${{ steps.get_version.outputs.VERSION }}
       - name: Push Docker image
         run: |
           docker push ghcr.io/harelm/spreet:latest
+          docker push ghcr.io/harelm/spreet:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [released]
 jobs:
-  publish:
+  publish-to-cargo:
     name: cargo publish
     runs-on: ubuntu-latest
     steps:
@@ -12,3 +12,23 @@ jobs:
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-to-ghcr:
+    name: docker publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build . -t ghcr.io/flother/spreet:latest
+        env:
+      - name: Push Docker image
+        run: |
+          docker push ghcr.io/flother/spreet:latest

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -2,7 +2,6 @@ name: Publish new release to crates.io
 on:
   release:
     types: [released]
-  workflow_dispatch:
 jobs:
   publish-to-cargo:
     name: cargo publish

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build . -t ghcr.io/harelm/spreet:latest -t ghcr.io/harelm/spreet:${{ steps.get_version.outputs.VERSION }}
+          docker build . -t ghcr.io/flother/spreet:latest -t ghcr.io/flother/spreet:${{ steps.get_version.outputs.VERSION }}
       - name: Push Docker image
         run: |
-          docker push ghcr.io/harelm/spreet:latest
-          docker push ghcr.io/harelm/spreet:${{ steps.get_version.outputs.VERSION }}
+          docker push ghcr.io/flother/spreet:latest
+          docker push ghcr.io/flother/spreet:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Build Docker image
         run: |
           docker build . -t ghcr.io/harelm/spreet:latest
-        env:
       - name: Push Docker image
         run: |
           docker push ghcr.io/harelm/spreet:latest

--- a/.github/workflows/publish-release-to-crates-io.yml
+++ b/.github/workflows/publish-release-to-crates-io.yml
@@ -2,6 +2,7 @@ name: Publish new release to crates.io
 on:
   release:
     types: [released]
+  workflow_dispatch:
 jobs:
   publish-to-cargo:
     name: cargo publish
@@ -27,8 +28,8 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build . -t ghcr.io/flother/spreet:latest
+          docker build . -t ghcr.io/harelm/spreet:latest
         env:
       - name: Push Docker image
         run: |
-          docker push ghcr.io/flother/spreet:latest
+          docker push ghcr.io/harelm/spreet:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM rust:latest AS build
-WORKDIR /usr/src/app
+WORKDIR /app
 COPY ./ ./
 RUN cargo build --release
 
 # Create a new stage for the final image
 FROM debian:latest
-WORKDIR /usr/src/app
+WORKDIR /app
 # Copy the binary from the build stage
-COPY --from=build /usr/src/app/target/release/spreet ./
+COPY --from=build /app/target/release/spreet ./
 CMD ["./spreet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:latest AS build
+WORKDIR /usr/src/app
+COPY ./ ./
+RUN cargo build --release
+
+# Create a new stage for the final image
+FROM debian:latest
+WORKDIR /usr/src/app
+# Copy the binary from the build stage
+COPY --from=build /usr/src/app/target/release/spreet ./
+CMD ["./spreet"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ FROM debian:latest
 WORKDIR /app
 # Copy the binary from the build stage
 COPY --from=build /app/target/release/spreet ./
-CMD ["./spreet"]
+ENTRYPOINT ["./spreet"]

--- a/README.md
+++ b/README.md
@@ -47,12 +47,15 @@ cargo install spreet
 
 Pre-built binaries are provided for MacOS, Linux, and Windows. The MacOS and Linux binaries are built for both Intel and ARM CPUs. Visit the [releases](https://github.com/flother/spreet/releases) page to download the latest version of Spreet.
 
-## Use the docker image
+### Using via Docker
+
+If you have [Docker](https://www.docker.com/) installed, you can run Spreet without installing it locally. The Docker image is available from the GitHub Container Registry:
 
 ```
-docker run -v ${pwd}:/app ghcr.io/flother/spreet
+docker run -v $(pwd):/app -w /app ghcr.io/flother/spreet icons my_style
 ```
 
+This command mounts your current directory as `/app` inside the container and sets it as the working directory. Replace `icons` and `my_style` with your actual input directory and output filename.
 ### Build from source
 
 You'll need a recent version of the Rust toolchain (try [Rustup](https://rustup.rs/) if you don't have it already). With that, you can check out this repository:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ cargo install spreet
 
 Pre-built binaries are provided for MacOS, Linux, and Windows. The MacOS and Linux binaries are built for both Intel and ARM CPUs. Visit the [releases](https://github.com/flother/spreet/releases) page to download the latest version of Spreet.
 
+## Use the docker image
+
+```
+docker run -v ${pwd}:/app ghcr.io/flother/spreet
+```
+
 ### Build from source
 
 You'll need a recent version of the Rust toolchain (try [Rustup](https://rustup.rs/) if you don't have it already). With that, you can check out this repository:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+In order to release a new version of this package the following steps are needed:
+1. Change the version in Cargo.toml file and push the changes.
+2. Tag the latest commit: `git tag vX.Y.Z`
+3. Push the tag to trigger the github action: `git push origin --tags`
+4. Go to Releases and publish the draft release, this will trigger an action to publish the latest release to Crate.io and GHCR.


### PR DESCRIPTION
- Resolves #83

This adds a simple docker file with two steps to allow minimal docker image size.
I've written the release instructions for future generations.
I've updates the CI for publish to also publish the latest version to GHCR and a tagged version.